### PR TITLE
Fix broken JSON, removing trailing commas

### DIFF
--- a/Gold-AMi-Stack-CFT-CI.json
+++ b/Gold-AMi-Stack-CFT-CI.json
@@ -511,7 +511,7 @@
 
                                     "Effect": "Allow",
                                     "Action": "sts:AssumeRole",
-                                   "Resource": { "Fn::Join": ["",["arn:aws:iam::*:role/",{"Ref":"roleName"}] ]},
+                                   "Resource": { "Fn::Join": ["",["arn:aws:iam::*:role/",{"Ref":"roleName"}] ]}
                                   },
                                  {
                                     "Effect": "Allow",
@@ -1904,7 +1904,7 @@
                         {
                            "Effect":"Allow",
                            "Action":["sts:AssumeRole"],
-                           "Resource": { "Fn::Join": ["",["arn:aws:iam::*:role/",{"Ref":"roleName"}] ]},
+                           "Resource": { "Fn::Join": ["",["arn:aws:iam::*:role/",{"Ref":"roleName"}] ]}
                         },
                         
                         {
@@ -2454,7 +2454,7 @@
                      "Sid": "StartContinuousAssessmentLambdaPolicyStmt2",
                      "Effect": "Allow",
                      "Action":[ 
-                     "ec2:DescribeImages", ],
+                     "ec2:DescribeImages" ],
                      "Resource": ["*"]
                      },  
                      {
@@ -2486,7 +2486,7 @@
                             "Resource": "*",
                             "Condition": {
                               "ForAllValues:StringEquals": {
-                                "aws:TagKeys": ["AMI-Type","ProductName","continuous-assessment-instance","ProductOSAndVersion","version",]
+                                "aws:TagKeys": ["AMI-Type","ProductName","continuous-assessment-instance","ProductOSAndVersion","version"]
                               }
                             }
                         },
@@ -2789,7 +2789,7 @@
                         "\n","        print('Terminating:'+key)",
                         "\n","        ec2.terminate_instances(InstanceIds=[key],DryRun=False)",
                         "\n","    sns.publish(TopicArn='", {"Ref":"ContinuousAssessmentResultsTopic"}, "',Message='['+', '.join(tagsList)+']')",
-                        "\n","    return jsonVal['run']",
+                        "\n","    return jsonVal['run']"
                      ]
                   ]
                }

--- a/Golden-AMI-Compliance-CFT.json
+++ b/Golden-AMI-Compliance-CFT.json
@@ -100,7 +100,7 @@
         "            if (error) { callback(error, null);}",
         "            else if (data.FailedEvaluations.length > 0) {callback(JSON.stringify(data), null);}",
         "            else {callback(null, data);}",
-        "        });});}});};",
+        "        });});}});};"
       ]]}
     },
     "Handler": "index.handler",
@@ -175,7 +175,7 @@
       "Owner": "CUSTOM_LAMBDA",
       "SourceDetails": [{
           "EventSource": "aws.config",
-          "MessageType": "ConfigurationItemChangeNotification", 
+          "MessageType": "ConfigurationItemChangeNotification"
       },
       {
           "EventSource": "aws.config",
@@ -186,6 +186,6 @@
     }
   },
   "DependsOn": "ConfigPermissionToCallLambda"
-}, 
+}
 }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The JSON for the cloudformation template is broken -- there are trailing commas which make it invalid. This PR removes the trailing commas so that the JSON is at least syntactically valid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
