### PR TITLE
Updating to nodejs8.10 as nodejs4.3 is not supported by AWS Lambda.

### DIFF
--- a/Golden-AMI-Compliance-CFT.json
+++ b/Golden-AMI-Compliance-CFT.json
@@ -104,7 +104,7 @@
       ]]}
     },
     "Handler": "index.handler",
-    "Runtime": "nodejs4.3",
+    "Runtime": "nodejs8.10",
     "Timeout": "30",
     "Role": {"Fn::GetAtt": ["LambdaExecutionRole", "Arn"]}
   }


### PR DESCRIPTION
*Issue #, if available:*
nodejs4.3 is not supported by AWS Lambda

*Description of changes:*
updated to nodejs8.10

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
